### PR TITLE
Hazards out of scope management

### DIFF
--- a/src/main/java/actors/Hazards.java
+++ b/src/main/java/actors/Hazards.java
@@ -33,5 +33,4 @@ public class Hazards extends Actor {
         posY += vy;
     }
 
-
 }

--- a/src/main/java/game/DriveDemo.java
+++ b/src/main/java/game/DriveDemo.java
@@ -154,9 +154,19 @@ public class DriveDemo extends Stage implements KeyListener {
         roadVerticalOffset %= Stage.HEIGHT;
 
         car.update();
+
+        //TODO: Possibly handle both modifiers and hazards into the actor array
+
+        // Updating hazards position
         for (int i = 0; i < hazards.size(); i++) {
             Hazards hazard = hazards.get(i);
             hazard.update();
+            if (hazard.getY() > Stage.HEIGHT){
+                hazard.setMarkedForRemoval(true);
+            }
+            if (hazard.isMarkedForRemoval()){
+                hazards.remove(i);
+            }
         }
 
 
@@ -174,7 +184,10 @@ public class DriveDemo extends Stage implements KeyListener {
         for (int i = 0; i < hazards.size(); i++) {
             Hazards hazard = hazards.get(i);
             if( car.getBounds().intersects(hazard.getBounds())) {
+                //TODO: Change 10 to retrieve hazard damage value
                 car.reduceHealth(10);
+
+                hazard.setMarkedForRemoval(true);
                 if( splat == null) {
                     splat = new Splat(this);
                     splat.setX(car.getX());


### PR DESCRIPTION
Previous debug methods displayed that hazard objects will persist after leaving the screen

Updated hazards to become marked for deletion and then on the next update() all hazards will be removed from the hazard array. Allowing Java's garbage collector to delete the unused objects.


This may be changed in the future to handle all modifier and hazard objects into the actor array. This would be a small change.